### PR TITLE
[FIX] Reset DOM element visibility on page load

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:8
+WORKDIR /usr/src/app
+COPY package*.json ./
+RUN npm install -g gulp@4.0.0
+RUN npm install --only=dev
+
+CMD ["gulp"]

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ apt install git nodejs npm
 
 Install Gulp 4 globally
 ```sh
-npm install -g gulpjs/gulp.git#4.0
+npm install -g gulp@next
 ```
 
 Download coinglacier.org

--- a/README.md
+++ b/README.md
@@ -107,7 +107,42 @@ or some attacker manages to sneak into your browser.
     they might record the private key you generated.
 
 ## Developers (install guide)
+### Dockerized setup
 
+Download coinglacier.org
+```sh
+git clone https://github.com/dalitsairio/coinglacier.org.git
+cd coinglacier.org
+git checkout develop
+```
+
+Create image
+```sh
+docker build -t coinglacier-org .
+```
+
+#### Development
+During development, run gulp watchers
+```sh
+docker run -t --rm -p 3000:3000 -v "$PWD":/usr/src/app coinglacier-org
+```
+Open http://localhost:3000 in your browser
+
+#### Build finished releases
+Bugfix releases
+```sh
+docker run -t --rm -v "$PWD":/usr/src/app coinglacier-org gulp build
+```
+Backwards compatible releases
+```sh
+docker run -t --rm -v "$PWD":/usr/src/app coinglacier-org gulp build-minor
+```
+Backwards incompatible releases
+```sh
+docker run -t --rm -v "$PWD":/usr/src/app coinglacier-org gulp build-major
+```
+
+### Without Docker
 Install git, NodeJS and NPM
 ```sh
 apt install git nodejs npm
@@ -129,12 +164,12 @@ Install dependencies
 ```sh
 npm install --only=dev
 ```
-### Development
+#### Development
 During development, run gulp watchers
 ```sh
 gulp
 ```
-### Build finished releases
+#### Build finished releases
 Bugfix releases
 ```sh
 gulp build

--- a/src/index.html
+++ b/src/index.html
@@ -1327,7 +1327,8 @@ Git Repo: https://github.com/dalitsairio/coinglacier.org.git
         <div id="actions">
             <button id="new-address" type="button" class="btn btn-dark btn-sm page-element single-wallet">New Address</button>
             <button id="new-mnemonic" type="button" class="btn btn-dark btn-sm page-element paper-wallet">New Mnemonic</button>
-            <button id="print-button" type="button" class="btn btn-dark btn-sm">Print</button>
+            <button id="print-button-loading" type="button" class="btn btn-dark btn-sm" disabled="disabled"><span class="micro-loader"></span>Print</button>
+            <button id="print-button" type="button" class="btn btn-dark btn-sm" style="display: none">Print</button>
             <div style="clear: both;"></div>
         </div>
 

--- a/src/index.html
+++ b/src/index.html
@@ -534,6 +534,8 @@ Git Repo: https://github.com/dalitsairio/coinglacier.org.git
 
 <body>
 
+<script src="js/cleanStartup.js" inline></script>
+
 <div id="page-loader">
     <span class="title text-center">loading wallet generator</span>
     <div id="spinner-wrapper"><div class="loader"></div></div>

--- a/src/index.html
+++ b/src/index.html
@@ -1327,8 +1327,9 @@ Git Repo: https://github.com/dalitsairio/coinglacier.org.git
         <div id="actions">
             <button id="new-address" type="button" class="btn btn-dark btn-sm page-element single-wallet">New Address</button>
             <button id="new-mnemonic" type="button" class="btn btn-dark btn-sm page-element paper-wallet">New Mnemonic</button>
-            <button id="print-button-loading" type="button" class="btn btn-dark btn-sm" disabled="disabled"><span class="micro-loader"></span>Print</button>
-            <button id="print-button" type="button" class="btn btn-dark btn-sm" style="display: none">Print</button>
+            <button id="print-button-loading" type="button" class="btn btn-dark btn-sm loading-button" disabled="disabled"><span class="micro-loader"></span>Print</button>
+            <button id="print-button-disabled" type="button" class="btn btn-dark btn-sm loading-button" disabled="disabled">Print</button>
+            <button id="print-button-enabled" type="button" class="btn btn-dark btn-sm loading-button" style="display: none">Print</button>
             <div style="clear: both;"></div>
         </div>
 

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -111,6 +111,7 @@ DOM.options.qrcodeLink = $('input#qrcode-links-check');
 DOM.actions = {};
 DOM.actions.newAddress = $('#actions #new-address');
 DOM.actions.newMnemonic = $('#actions #new-mnemonic');
+DOM.actions.print = {};
 DOM.actions.print.enabled = $('#actions #print-button-enabled');
 DOM.actions.print.loading = $('#actions #print-button-loading');
 DOM.actions.print.disabled = $('#actions #print-button-disabled');
@@ -830,6 +831,7 @@ function PrivkeyDecryption() {
         alignWallet();
 
         if (pages.decryptPrivKey.showWallet) {
+            blockInputFields();
             initDecryption();
         }
     }
@@ -854,6 +856,16 @@ function PrivkeyDecryption() {
     const verifyPassword = () => DOM.decPriv.pass.val() !== '';
     const checkInputsFulfilled = () => verifyPrivKey() && verifyPassword();
 
+    const blockInputFields = () => {
+        DOM.decPriv.privKey.prop('disabled', true);;
+        DOM.decPriv.pass.prop('disabled', true);
+    }
+
+    const unblockInputFields = () => {
+        DOM.decPriv.privKey.prop('disabled', false);;
+        DOM.decPriv.pass.prop('disabled', false);
+    }
+
     const initDecryption = () => {
         let encryptedPrivKey = DOM.decPriv.privKey.val();
         let password = DOM.decPriv.pass.val();
@@ -870,15 +882,18 @@ function PrivkeyDecryption() {
         bitcoinLoader.getCredentialsFromEncryptedPrivKey(encryptedPrivKey, password, isTestnet, function (credentials) {
             wallet.fillCredentialsHTML(0, 0, credentials.address, credentials.privateKey);
             printButton.enable();
+            unblockInputFields();
         }, function () {
             DOM.decPriv.wrongNetwork.show();
             DOM.decPriv.pass.addClass(CSS_CLASS_INVALID);
             $('.wallet-account').hide();
             printButton.disable();
+            unblockInputFields();
         }, function () {
             DOM.decPriv.pass.addClass(CSS_CLASS_INVALID);
             $('.wallet-account').hide();
             printButton.disable();
+            unblockInputFields();
         });
     }
 

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -111,9 +111,9 @@ DOM.options.qrcodeLink = $('input#qrcode-links-check');
 DOM.actions = {};
 DOM.actions.newAddress = $('#actions #new-address');
 DOM.actions.newMnemonic = $('#actions #new-mnemonic');
-DOM.actions.printEnabled = $('#actions #print-button-enabled');
-DOM.actions.printLoading = $('#actions #print-button-loading');
-DOM.actions.printDisabled = $('#actions #print-button-disabled');
+DOM.actions.print.enabled = $('#actions #print-button-enabled');
+DOM.actions.print.loading = $('#actions #print-button-loading');
+DOM.actions.print.disabled = $('#actions #print-button-disabled');
 
 DOM.popovers = {};
 DOM.popovers.testnetWarning = $('#testnet-warning');
@@ -317,7 +317,7 @@ DOM.options.qrcodeLink.change(options.toggleQRcodeLink);
 // Actions
 DOM.actions.newAddress.click(init.wallet);
 DOM.actions.newMnemonic.click(init.wallet);
-DOM.actions.printEnabled.click(print);
+DOM.actions.print.enabled.click(print);
 
 // Decrypt mnemonic page
 DOM.decMnemonic.mnemonic.change(mnemonicDecryption.mnemonicChanged);
@@ -916,23 +916,23 @@ function PrintButton() {
 
     this.disable = () => {
         disableAllButtons();
-        DOM.actions.printDisabled.show();
+        DOM.actions.print.disabled.show();
     }
 
     this.setLoading = () => {
         disableAllButtons();
-        DOM.actions.printLoading.show();
+        DOM.actions.print.loading.show();
     }
 
     this.enable = () => {
         disableAllButtons();
-        DOM.actions.printEnabled.show();
+        DOM.actions.print.enabled.show();
     }
 
     const disableAllButtons = () => {
-        DOM.actions.printEnabled.hide();
-        DOM.actions.printLoading.hide();
-        DOM.actions.printDisabled.hide();
+        DOM.actions.print.enabled.hide();
+        DOM.actions.print.loading.hide();
+        DOM.actions.print.disabled.hide();
     }
 }
 

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -170,11 +170,21 @@ DOM.footer.donations.bech32QR = $('#canvas-donations-bech32').get(0);
 DOM.footer.pgpSignature = $('#pgp-signature');
 
 DOM.footer.windows = {};
+DOM.footer.windows.all = $('footer .footer-window');
 DOM.footer.windows.online = $('footer #online-check-wrapper');
 DOM.footer.windows.crypto = $('footer #crypto-check-wrapper');
 DOM.footer.windows.mocha = $('footer #mocha-wrapper');
 DOM.footer.windows.segwitQR = $('footer #donation-segwit-qr-wrapper');
 DOM.footer.windows.bech32QR = $('footer #donation-bech32-qr-wrapper');
+
+
+// //////////////////////////////////////////////////
+// Page view at startup
+// //////////////////////////////////////////////////
+
+let initView = {};
+initView.visibleElements = [DOM.pageLoader, DOM.body];
+initView.hiddenElements = [DOM.root, DOM.footer.windows.all];
 
 
 // //////////////////////////////////////////////////
@@ -336,6 +346,7 @@ function Init() {
 
     this.app = () => {
 
+        this.startupView();
         network();
         page();
         popovers();
@@ -350,6 +361,10 @@ function Init() {
         footer.securityChecks.runAll();
     }
 
+    this.startupView = () => {
+        initView.hiddenElements.map(dom => { dom.hide(); });
+        initView.visibleElements.map(dom => { dom.show(); });
+    }
 
     this.wallet = () => {
 
@@ -736,7 +751,7 @@ function MnemonicDecryption() {
         initDecryption();
     }
 
-    this.passwordChanged = () => {      
+    this.passwordChanged = () => {
         formCheck.validateInput(verifyPassword(), DOM.decMnemonic.pass);
         initDecryption();
     }
@@ -758,7 +773,7 @@ function MnemonicDecryption() {
     const verifyPassword = () => DOM.decMnemonic.pass.val() !== '';
 
     const initDecryption = () => {
-        
+
         if (checkInputsFulfilled()) {
             let encryptedMnemonic = DOM.decMnemonic.mnemonic.val();
             password = DOM.decMnemonic.pass.val();
@@ -832,7 +847,7 @@ function PrivkeyDecryption() {
     const decryptPrivKey = (encryptedPrivKey, password) => {
 
         let isTestnet = networkId >= 10;
-        
+
         bitcoinLoader.getCredentialsFromEncryptedPrivKey(encryptedPrivKey, password, isTestnet, function (credentials) {
             wallet.fillCredentialsHTML(0, 0, credentials.address, credentials.privateKey);
         }, function () {
@@ -1407,7 +1422,7 @@ function FormCheck() {
     }
 
     this.validateInput = (condition, domElement) => {
-        this.removeValidityClasses(domElement);       
+        this.removeValidityClasses(domElement);
         this.setValidityClass(condition, domElement);
     }
 

--- a/src/js/cleanStartup.js
+++ b/src/js/cleanStartup.js
@@ -1,0 +1,2 @@
+// dont show anything until the page is loaded
+document.getElementsByTagName("BODY")[0].style.display = "none";

--- a/src/scss/components/_actions.scss
+++ b/src/scss/components/_actions.scss
@@ -5,7 +5,7 @@
     padding: 0.5rem 1.2rem;
     position: relative;
     
-    #print-button, #print-button-loading {
+    .loading-button {
         float: right;
 
         .micro-loader {

--- a/src/scss/components/_actions.scss
+++ b/src/scss/components/_actions.scss
@@ -5,8 +5,13 @@
     padding: 0.5rem 1.2rem;
     position: relative;
     
-    #print-button {
+    #print-button, #print-button-loading {
         float: right;
+
+        .micro-loader {
+            float: left;
+            margin: 0.1rem 0.4rem 0 0;
+        }
     }
 }
 

--- a/src/scss/components/_loader.scss
+++ b/src/scss/components/_loader.scss
@@ -47,6 +47,16 @@
     width: 1.5625rem;
 }
 
+.micro-loader {
+    -webkit-animation: spin 2s linear infinite; /* Safari */
+    animation: spin 1s linear infinite;
+    border: 0.2rem solid #f3f3f3;
+    border-radius: 50%;
+    border-top: 0.2rem solid $mainnet-primary-color;
+    height: 1rem;
+    width: 1rem;
+}
+
 @media screen and (max-width: $bootstrap-sm) {
 	#page-loader {
 		#spinner-wrapper {

--- a/src/scss/themes/_testnet.scss
+++ b/src/scss/themes/_testnet.scss
@@ -28,4 +28,8 @@
     .small-loader {
         border-top: 5px solid $testnet-primary-color;
     }
+
+    .micro-loader {
+        border-top: 3px solid $testnet-primary-color;
+    }
 }


### PR DESCRIPTION
Whenever the coinglacier.org page is stored in the browser hitting CTRL + s, there are two options: "Web Page complete", and "Web Page, HTML only". The former causes problems, however, it is unfortunately also most browsers default option.

The problem it causes manifests as follows: The state the HTML is stored in is after loading the page. Henceforth, the loader page is not displayed, but instead the wallet is directly showed, even though it is not ready yet.

This PR fixes this issue by setting the correct visibility options each time the page is loaded.